### PR TITLE
FIX: iOS shows black video

### DIFF
--- a/src/Video.js
+++ b/src/Video.js
@@ -12,7 +12,7 @@ class Video extends Component {
   }
 
   render() {
-    return <video className="Video" ref={ref => (this.video = ref)} />;
+    return <video className="Video" ref={ref => (this.video = ref)} playsInline />;
   }
 }
 


### PR DESCRIPTION
playsinline needs to be added for iOS compatibility (at least Safari)

solution found here:
https://stackoverflow.com/a/51432655/828184

The camelcase writing of playsInline is also important see comment:
https://stackoverflow.com/questions/20347352/html5-video-tag-not-working-in-safari-iphone-and-ipad/28779883#comment102467663_51432655

After the fix on my iPhone7 with iOS 14.01 it works in Safari but still not in Chrome but it seems to be fixed since around November with iOS 14.3 beta1:
https://bugs.chromium.org/p/chromium/issues/detail?id=752458#c41
(not verified yet)