### PR TITLE
Enable/Disable camera working reliably

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,12 +57,12 @@ class App extends Component {
   }
 
   toggleVideo() {
-    eyeson.send({
-      type: 'change_stream',
-      stream: this.state.local,
-      video: !this.state.video,
-      audio: this.state.audio,
-    });
+    if (this.state.video) {
+      StreamHelpers.disableCamera(this.state.local);
+    } else {
+      StreamHelpers.enableCamera(this.state.local);
+    }
+    
     this.setState({video: !this.state.video});
   }
 


### PR DESCRIPTION
The way disabling the camera didn't work reliably since we have a self-preview in our videoroom. The self-preview of the local stream stayed black. Using StreamHelpers also for the camera seems to work more stable and fixed the issue. Our code drifted quite a bit but if you agree that this is a better solution I think it should be merged. Please double check functionality before merging.